### PR TITLE
Linux support (targetting Wine processes)

### DIFF
--- a/DoukMemEd.pro
+++ b/DoukMemEd.pro
@@ -28,9 +28,13 @@ SOURCES += \
         main.cpp \
         doukmemed.cpp
 
+win32: SOURCES += lpa_windows.cpp
+else: SOURCES += lpa_unix.cpp
+
 HEADERS += \
         doukmemed.h \
-    doukutsu.h
+        doukutsu.h \
+        lpa.h
 
 FORMS += \
         doukmemed.ui
@@ -40,4 +44,4 @@ qnx: target.path = /tmp/$${TARGET}/bin
 else: unix:!android: target.path = /opt/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
 
-LIBS += -lpsapi
+win32: LIBS += -lpsapi

--- a/doukmemed.cpp
+++ b/doukmemed.cpp
@@ -2,9 +2,9 @@
 #include "ui_doukmemed.h"
 #include <QMessageBox>
 #include <iostream>
-#include <psapi.h>
 #include <string>
 #include <sstream>
+#include <stdint.h>
 #include "doukutsu.h"
 using namespace std;
 
@@ -32,33 +32,40 @@ void DoukMemEd::on_btnAttach_clicked()
             ui->leExeName->setText(exeName);
         }
         // attach
-        DWORD *pids;
-        if ((pids = new DWORD[1024]) == nullptr) {
-            QMessageBox::critical(this, QString("Attach fail"), QString("Could not allocate enough memory to enumerate processes.\nI only wanted 4096 bytes..."));
+        QList<intptr_t> processes = QList<intptr_t>();
+        if(!LPA::getProcesses(processes)) {
+            QMessageBox::critical(this, QString("Attach fail"), QString("Process enumeration failed, error code %1.").arg(LPA::getLastError()));
             return;
         }
 
-        DWORD szRet;
-        if(!EnumProcesses(pids, sizeof(DWORD)*1024, &szRet)) {
-            QMessageBox::critical(this, QString("Attach fail"), QString("Process enumeration failed, error code %1.").arg(GetLastError()));
-            return;
-        }
-
-        char name[513];
-        string doukutsu = exeName.toUtf8().constData();
-        DWORD i = 0;
-        for (; i < szRet; i++) {
-            proc = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_VM_OPERATION | PROCESS_VM_WRITE, true, pids[i]);
-            if (proc != nullptr) {
-                DWORD ns = GetModuleFileNameExA(proc, nullptr, name, 512);
-                if (ns != 0) {
-                    char* nameStart = strrchr(name, '\\') + 1;
-                    if (nameStart == doukutsu)
-                        break;
+        proc = nullptr;
+        for (intptr_t ip : processes) {
+            proc = new LPA::Process(ip);
+            if ((proc->isValid()) && (proc->matchesNameTemplate(exeName))) {
+                cout << "Attempting attach to PID " << proc->getPID() << endl;
+                if (!proc->canBeginMemoryAccess()) {
+                    delete proc;
+                    QMessageBox::critical(this, QString("Attach fail"), QString(
+                        "The Cave Story process was found, but access to memory was not available.\n"
+#ifdef WINDOWS
+                        "It is possible that the wrong target was chosen, or the target was run as Administrator or another user and this program wasn't.\n"
+#else
+                        "It is possible that the wrong target was chosen, or the target was run as another user.\n"
+#endif
+#ifdef __linux__
+                        // Canonical, may I ask how YAMA is added security? If something can go ptracing arbitrary targets, it can just as well read the data off disk.
+                        "On certain Linux kernel builds, /proc/sys/kernel/yama/ptrace_scope must be set to 0 to allow ptrace between user processes.\n"
+                        "This will apply until the next reboot.\n"
+                        "This must be done with \"su\" followed by \"echo 0 > /proc/sys/kernel/yama/ptrace_scope\".\n"
+#endif
+                        "The specific situation depends on various factors, though."
+                        ));
+                    return;
                 }
-                CloseHandle(proc);
-                proc = nullptr;
+                break;
             }
+            delete proc;
+            proc = nullptr;
         }
 
         if (proc == nullptr) {
@@ -66,7 +73,7 @@ void DoukMemEd::on_btnAttach_clicked()
             return;
         }
 
-        cout << "Successfully attached to Cave Story process (PID: " << pids[i] << ").\r\n";
+        cout << "Successfully attached to Cave Story process (PID: " << proc->getPID() << ")." << endl;
         lockUpdateTimer->start(100); // locks are updated every 1/10th of a second
         ui->leExeName->setDisabled(true);
         ui->btnAttach->setText(QString("Detach"));
@@ -80,7 +87,7 @@ void DoukMemEd::on_btnAttach_clicked()
 
 void DoukMemEd::detach() {
     if (proc != nullptr)
-        CloseHandle(proc);
+        delete proc;
     proc = nullptr;
     cout << "Detached from Cave Story process.\r\n";
     lockUpdateTimer->stop();
@@ -102,9 +109,7 @@ void DoukMemEd::setWidgetsDisabled(bool v) {
 bool DoukMemEd::checkProcStillRunning() {
     if (proc == nullptr)
         return false;
-    DWORD code;
-    GetExitCodeProcess(proc, &code);
-    if (code == STILL_ACTIVE)
+    if (proc->isStillAlive())
         return true;
     QMessageBox::information(this, QString("Doukutsu process dead"), QString("The Cave Story process has ended."));
     detach();
@@ -115,13 +120,13 @@ void DoukMemEd::updateLocks() {
     if (!checkProcStillRunning())
         return;
     if (ui->cbLockHP->isChecked()) {
-        WORD word = static_cast<WORD>(ui->sbCurHP->value());
+        uint16_t word = static_cast<uint16_t>(ui->sbCurHP->value());
         // max health also has to be set to this value
         // (max HP spinbox is disabled by lock checkbox being toggled on)
         ui->sbMaxHP->setValue(word);
-        WriteProcessMemory(proc, ptr(CS_health_maximum), &word, sizeof(WORD), nullptr);
-        WriteProcessMemory(proc, ptr(CS_health_displayed), &word, sizeof(WORD), nullptr);
-        WriteProcessMemory(proc, ptr(CS_health_current), &word, sizeof(WORD), nullptr);
+        proc->writeMemory(CS_health_maximum, &word, sizeof(uint16_t));
+        proc->writeMemory(CS_health_displayed, &word, sizeof(uint16_t));
+        proc->writeMemory(CS_health_current, &word, sizeof(uint16_t));
     }
 }
 
@@ -129,10 +134,10 @@ void DoukMemEd::on_btnReadMem_clicked()
 {
     if (!checkProcStillRunning())
         return;
-    WORD word;
-    ReadProcessMemory(proc, ptr(CS_health_maximum), &word, sizeof(WORD), nullptr);
+    uint16_t word;
+    proc->readMemory(CS_health_maximum, &word, sizeof(uint16_t));
     ui->sbMaxHP->setValue(word);
-    ReadProcessMemory(proc, ptr(CS_health_current), &word, sizeof(WORD), nullptr);
+    proc->readMemory(CS_health_current, &word, sizeof(uint16_t));
     ui->sbCurHP->setValue(word);
 }
 
@@ -140,17 +145,19 @@ void DoukMemEd::on_sbMaxHP_valueChanged(int arg1)
 {
     if (!checkProcStillRunning())
         return;
-    WriteProcessMemory(proc, ptr(CS_health_maximum), &arg1, sizeof(WORD), nullptr);
+    uint16_t val = static_cast<uint16_t>(arg1);
+    proc->writeMemory(CS_health_maximum, &val, sizeof(uint16_t));
 }
 
 void DoukMemEd::on_sbCurHP_valueChanged(int arg1)
 {
     if (!checkProcStillRunning())
         return;
-    WriteProcessMemory(proc, ptr(CS_health_current), &arg1, sizeof(WORD), nullptr);
-    WriteProcessMemory(proc, ptr(CS_health_displayed), &arg1, sizeof(WORD), nullptr);
+    uint16_t val = static_cast<uint16_t>(arg1);
+    proc->writeMemory(CS_health_current, &val, sizeof(uint16_t));
+    proc->writeMemory(CS_health_displayed, &val, sizeof(uint16_t));
     if (ui->cbLockHP->isChecked())
-        WriteProcessMemory(proc, ptr(CS_health_maximum), &arg1, sizeof(WORD), nullptr);
+        proc->writeMemory(CS_health_maximum, &val, sizeof(uint16_t));
 }
 
 void DoukMemEd::on_cbLockHP_clicked(bool checked)

--- a/doukmemed.h
+++ b/doukmemed.h
@@ -2,8 +2,8 @@
 #define DOUKMEMED_H
 
 #include <QMainWindow>
-#include "windows.h"
 #include <QTimer>
+#include "lpa.h"
 
 namespace Ui {
 class DoukMemEd;
@@ -28,7 +28,7 @@ private slots:
 
 private:
     Ui::DoukMemEd *ui;
-    HANDLE proc = nullptr;
+    LPA::Process *proc = nullptr;
     void detach();
     bool checkProcStillRunning();
     void setWidgetsDisabled(bool v);

--- a/doukutsu.h
+++ b/doukutsu.h
@@ -6,7 +6,4 @@
 #define CS_health_displayed 0x49E6CC
 #define CS_health_current 0x49E6D4
 
-// Read/WriteProcessMemory(lpBaseAddress: ptr(PTR_DEFINE))
-#define ptr(x) reinterpret_cast<LPVOID>(x)
-
 #endif // DOUKUTSU_H

--- a/lpa.h
+++ b/lpa.h
@@ -1,0 +1,38 @@
+// Loaded Process Access (LPA)
+#ifndef LPA_H
+#define LPA_H
+
+#include <QList>
+#include <stdint.h>
+
+namespace LPA {
+    class Process
+    {
+    public:
+        Process(intptr_t pid);
+        inline bool isValid() {
+            return valid;
+        }
+        inline intptr_t getPID() {
+            return pid;
+        }
+        bool isStillAlive();
+        bool matchesNameTemplate(QString name);
+        // Note: It's best if the Lea implementation *doesn't* open with full permissions unless necessary, but the Windows impl. was ported.
+        // Still: Only do this if you're sure this is the process you want. Don't want to trigger anticheats.
+        bool canBeginMemoryAccess();
+        void readMemory(uint32_t address, void * res, size_t ressz);
+        void writeMemory(uint32_t address, void * res, size_t ressz);
+        ~Process();
+    private:
+        intptr_t pid;
+        // Implementation-specific contents.
+        intptr_t handle, handle2;
+        // Set during constructor.
+        bool valid;
+    };
+    bool getProcesses(QList<intptr_t> & processes);
+    unsigned int getLastError();
+}
+
+#endif // LPA_H

--- a/lpa_unix.cpp
+++ b/lpa_unix.cpp
@@ -1,0 +1,101 @@
+// This one's going to be super-easy.
+// That said, for reference, see "man 5 proc", and "man 2 ptrace".
+
+#include <QDir>
+#include <string>
+#include "lpa.h"
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <QTextStream>
+
+// handle is used for access to the process directory (done separately to somewhat minimize race condition stuff).
+// handle2 is basically a bool used to indicate if we've taken over ptrace or not.
+
+LPA::Process::Process(intptr_t pidx) {
+    pid = pidx;
+    valid = true;
+
+    QString qs = QString("/proc/%1").arg(pidx);
+    QByteArray qba = qs.toUtf8();
+
+    handle = open(qba.constData(), O_RDONLY);
+    if (handle < 0)
+        valid = false;
+    handle2 = -1;
+}
+
+LPA::Process::~Process() {
+    if (valid) {
+        close((int) handle);
+        if (handle2 >= 0)
+            close((int) handle2);
+    }
+}
+
+bool LPA::Process::isStillAlive() {
+    // Attempting to do anything on a dead process will result in error.
+    // Thus, if we could access the process status before, and we no longer can, it's dead.
+    int fd = openat((int) handle, "status", O_RDONLY);
+    if (fd < 0)
+        return false;
+    close(fd);
+    return true;
+}
+
+bool LPA::Process::matchesNameTemplate(QString post) {
+    int nm = openat((int) handle, "comm", O_RDONLY);
+    if (nm < 0)
+        return false;
+
+    FILE * stdl = fdopen(nm, "rb");
+    if (!stdl) {
+        close(nm);
+        return false;
+    }
+    bool answer;
+    {
+        QTextStream qts(stdl, QIODevice::ReadOnly);
+        answer = post == qts.readLine();
+    }
+    fclose(stdl);
+    return answer;
+}
+
+bool LPA::Process::canBeginMemoryAccess() {
+    if (handle2 < 0)
+        handle2 = openat((int) handle, "mem", O_RDWR);
+    return handle2 >= 0;
+}
+
+void LPA::Process::readMemory(uint32_t address, void * res, size_t ressz) {
+    if (handle2 >= 0) {
+        lseek(handle2, address, SEEK_SET);
+        read(handle2, res, ressz);
+    }
+}
+
+void LPA::Process::writeMemory(uint32_t address, void * res, size_t ressz) {
+    if (handle2 >= 0) {
+        lseek(handle2, address, SEEK_SET);
+        write(handle2, res, ressz);
+    }
+}
+
+bool LPA::getProcesses(QList<intptr_t> & processes) {
+    QDir qd("/proc");
+    for (QString & qs : qd.entryList()) {
+        bool ok = false;
+        intptr_t r = (intptr_t) qs.toLong(&ok);
+        if (ok)
+            processes.append(r);
+    }
+    return true;
+}
+
+unsigned int LPA::getLastError() {
+    return (unsigned int) errno;
+}

--- a/lpa_windows.cpp
+++ b/lpa_windows.cpp
@@ -1,0 +1,83 @@
+#define LEA_WINDOWS_MAX_PROCESSES 8192
+
+#include <string>
+#include "lpa.h"
+
+// Use for checking compilability
+//#include <wine/windows/windows.h>
+//#include <wine/windows/psapi.h>
+//#include <wine/windows/winbase.h>
+
+#include <windows.h>
+#include <psapi.h>
+#include <winbase.h>
+
+LPA::Process::Process(intptr_t pidx) {
+    pid = pidx;
+    handle = (intptr_t) OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_VM_OPERATION | PROCESS_VM_WRITE, true, (DWORD) pidx);
+    if (!handle) {
+        // Handle was uncreatable, object is invalid.
+        valid = false;
+    } else {
+        valid = true;
+    }
+}
+
+LPA::Process::~Process() {
+    if (valid)
+        CloseHandle((HANDLE) handle);
+}
+
+bool LPA::Process::isStillAlive() {
+    DWORD code = STILL_ACTIVE + 1; // In case of error, this ensures it's not assumed to be alive.
+    GetExitCodeProcess((void *) handle, &code);
+    return code == STILL_ACTIVE;
+}
+
+bool LPA::Process::matchesNameTemplate(QString post) {
+    char name[513];
+    // Must be kept in scope to ensure that the constData's conversion to an std::string occurs correctly.
+    QByteArray qba = post.toUtf8();
+    std::string doukutsu = qba.constData();
+    DWORD ns = GetModuleFileNameExA((HANDLE) handle, nullptr, name, 512);
+    if (ns != 0) {
+        char* nameStart = strrchr(name, '\\');
+        if (nameStart) {
+            nameStart++;
+        } else {
+            nameStart = name;
+        }
+        return nameStart == doukutsu;
+    }
+    return false;
+}
+
+bool LPA::Process::canBeginMemoryAccess() {
+    return true;
+}
+
+void LPA::Process::readMemory(uint32_t address, void * res, size_t ressz) {
+    ReadProcessMemory((HANDLE) handle, (LPVOID) address, res, ressz, NULL);
+}
+
+void LPA::Process::writeMemory(uint32_t address, void * res, size_t ressz) {
+    WriteProcessMemory((HANDLE) handle, (LPVOID) address, res, ressz, NULL);
+}
+
+bool LPA::getProcesses(QList<intptr_t> & processes) {
+    DWORD pids[LEA_WINDOWS_MAX_PROCESSES];
+    DWORD szRet;
+    if(!EnumProcesses(pids, sizeof(pids), &szRet))
+        return false;
+    DWORD * ptr = pids;
+    while (szRet) {
+        processes.append(*ptr);
+        ptr++;
+        szRet -= 4;
+    }
+    return true;
+}
+
+unsigned int LPA::getLastError() {
+    return GetLastError();
+}


### PR DESCRIPTION
NOTE: Building not tested on Windows, so poke me if I broke that.
This abstracts the way process memory access is handled and uses that to implement a procfs backend. Theoretically it's for BSDs+Linux but it seems they don't all seem to have procfs on by default or it's rearranged a little, so it's mostly just for Linux.